### PR TITLE
Fix mongodb `bind source path does not exist` error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mongo:3.5
     volumes:
       - type: bind
-        source: ./data/mongo
+        source: ./data/db
         target: /data/db
   web:
     image: branchzero/yapi:1.3.4


### PR DESCRIPTION
修复 data 目录下缺少 mongo 目录导致的启动时出现  bind source path does not exist 的错误